### PR TITLE
Removed a space before the text "portfolio/resume.pdf" in line 36 of …

### DIFF
--- a/portfolio/templates/portfolio/base.html
+++ b/portfolio/templates/portfolio/base.html
@@ -33,7 +33,7 @@
       <div class="collapse navbar-collapse text-center" id="navbarNav">
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">
-            <a class="nav-link" href="{% static " portfolio/resume.pdf" %}">Resume</a>
+            <a class="nav-link" href="{% static "portfolio/resume.pdf" %}">Resume</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="https://www.linkedin.com/in/nick-walter/" target="_blank">LinkedIn</a>


### PR DESCRIPTION
…the base.html template file

Removed a single blank space before the text "portfolio/resume.pdf" in line 36 of the base.html file found in folder \portfolio\templates\portfolio. It was causing the Commander-in-Chief's resume not to open. :-)